### PR TITLE
Fix ClassCastException when a schema is used within a s/or spec

### DIFF
--- a/src/compute/spec1_select.cljc
+++ b/src/compute/spec1_select.cljc
@@ -44,14 +44,19 @@
 
         s/Spec
         (conform* [_ m]
-          (let [req-ks (set (req-ks-f *conform-path*))
-                ks (set (keys m))]
-            (if (not (sets/subset? req-ks ks))
+          (let [req-ks (set (req-ks-f *conform-path*))]
+            (cond
+              (not (map? m))
               ::s/invalid
+              (not (sets/subset? req-ks (set (keys m))))
+              ::s/invalid
+              :else
               (reduce-kv
                 (fn [m attr v]
                   (let [c (binding [*conform-path* (conj *conform-path* attr)]
-                            (s/conform attr v))]
+                            (if (s/get-spec attr)
+                              (s/conform attr v)
+                              v))]
                     (if (s/invalid? c)
                       (reduced c)
                       (assoc m attr c))))

--- a/test/compute/spec1_select_test.cljc
+++ b/test/compute/spec1_select_test.cljc
@@ -28,7 +28,7 @@
 
 (s/def ::user-or-id
   (s/or :id ::id
-        :user map?))
+        :user ::user))
 
 
 (s/def ::movie-times-user (ssel/select ::user [::id ::addr {::addr [::zip]}]))

--- a/test/compute/spec1_select_test.cljc
+++ b/test/compute/spec1_select_test.cljc
@@ -26,6 +26,10 @@
 (s/def ::last string?)
 (s/def ::user (ssel/schema [::id ::first ::last ::addr ::foods]))
 
+(s/def ::user-or-id
+  (s/or :id ::id
+        :user map?))
+
 
 (s/def ::movie-times-user (ssel/select ::user [::id ::addr {::addr [::zip]}]))
 (s/def ::foods-user (ssel/select ::user [::id {::foods [::food-name]}]))
@@ -50,7 +54,13 @@
     (is (= ::s/invalid
            (s/conform ::user
                       {::id   1
-                       ::addr {::zip "invalid"}})))))
+                       ::addr {::zip "invalid"}}))))
+  (testing "valid or"
+    (is (= [:id 1]
+           (s/conform ::user-or-id 1))))
+  (testing "invalid or"
+    (is (= ::s/invalid
+           (s/conform ::user-or-id "")))))
 
 (deftest schema-explain-test
   (testing "empty map"


### PR DESCRIPTION
**Expected**
`s/conform` returns `::s/invalid` when passed an input that does not pass the spec. 

**Actual**
```clojure
(s/def ::id int?)
(s/def ::user (ssel/schema [::id]))

(s/def ::user-or-id
  (s/or :id ::id
        :user ::user))

(s/valid? ::user-or-id {"a" 1})
Execution error (ClassCastException) at compute.spec1-select/schema-impl$reify$fn$fn (spec1_select.cljc:54).
class java.lang.String cannot be cast to class clojure.lang.IFn (java.lang.String is in module java.base of loader 'bootstrap'; clojure.lang.IFn is in unnamed module of loader 'app')

(s/valid? ::user-or-id "")
Execution error (IllegalArgumentException) at compute.spec1_select$schema_impl$reify__5746/conform_STAR_ (spec1_select.cljc:51).
No implementation of method: :kv-reduce of protocol: #'clojure.core.protocols/IKVReduce found for class: java.lang.String
```